### PR TITLE
Fix warnings

### DIFF
--- a/modules/currencies/src/mock.rs
+++ b/modules/currencies/src/mock.rs
@@ -57,7 +57,7 @@ impl frame_system::Config for Runtime {
 type Balance = u128;
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
 		Default::default()
 	};
 }

--- a/modules/evm-accounts/src/mock.rs
+++ b/modules/evm-accounts/src/mock.rs
@@ -63,7 +63,7 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
 		Default::default()
 	};
 }
@@ -93,7 +93,7 @@ pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Runtime, B
 
 pub struct EvmAccountsOnClaimHandler;
 impl evm_accounts::Handler<AccountId> for EvmAccountsOnClaimHandler {
-	fn handle(who: &AccountId) -> DispatchResult {
+	fn handle(_who: &AccountId) -> DispatchResult {
 		Ok(())
 	}
 }

--- a/modules/evm/src/mock.rs
+++ b/modules/evm/src/mock.rs
@@ -72,7 +72,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |currency_id: CurrencyId| -> u64 {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> u64 {
 		Default::default()
 	};
 }

--- a/modules/poc/src/benchmarking.rs
+++ b/modules/poc/src/benchmarking.rs
@@ -1,10 +1,9 @@
 #![cfg(feature = "runtime-benchmarks")]
 
-use crate::{*, Module as Poc};
+use crate::{*};
 use frame_benchmarking::{benchmarks, account, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
-use primitives::{Balance, currency::REEF, time::DAYS};
-use sp_std::prelude::*;
+use primitives::{currency::REEF, time::DAYS};
 
 benchmarks! {
 	where_clause { where BalanceOf<T>: From<u128> }

--- a/modules/poc/src/benchmarking.rs
+++ b/modules/poc/src/benchmarking.rs
@@ -25,12 +25,12 @@ benchmarks! {
 			T::Currency::deposit_creating(&voter, BalanceOf::<T>::from(100_001 * REEF));
 			T::Currency::deposit_creating(&candidate, BalanceOf::<T>::from(1_000_001 * REEF));
 
-			Pallet::<T>::start_candidacy(
+			let _ = Pallet::<T>::start_candidacy(
 				RawOrigin::Signed(candidate.clone()).into()
 			);
 
 			let amount: BalanceOf<T> = BalanceOf::<T>::from(100_000 * REEF);
-			Pallet::<T>::commit(
+			let _ = Pallet::<T>::commit(
 				RawOrigin::Signed(voter.clone()).into(),
 				amount,
 				LockDuration::OneYear,
@@ -59,7 +59,7 @@ benchmarks! {
 		let deposit: BalanceOf<T> = BalanceOf::<T>::from(1_000_001 * REEF);
 		T::Currency::deposit_creating(&alice, deposit);
 
-		Pallet::<T>::start_candidacy(
+		let _ = Pallet::<T>::start_candidacy(
 			RawOrigin::Signed(alice.clone()).into(),
 		);
 
@@ -88,7 +88,7 @@ benchmarks! {
 		let amount: BalanceOf<T> = BalanceOf::<T>::from(100_000 * REEF);
 
 		// she makes initial commitment
-		Pallet::<T>::commit(
+		let _ = Pallet::<T>::commit(
 			RawOrigin::Signed(alice.clone()).into(),
 			amount,
 			LockDuration::OneYear,
@@ -108,7 +108,7 @@ benchmarks! {
 		let amount: BalanceOf<T> = BalanceOf::<T>::from(100_000 * REEF);
 
 		// she makes initial commitment
-		Pallet::<T>::commit(
+		let _ = Pallet::<T>::commit(
 			RawOrigin::Signed(alice.clone()).into(),
 			amount,
 			LockDuration::OneYear,
@@ -128,7 +128,7 @@ benchmarks! {
 		let amount: BalanceOf<T> = BalanceOf::<T>::from(100_000 * REEF);
 
 		// she makes initial commitment
-		Pallet::<T>::commit(
+		let _ = Pallet::<T>::commit(
 			RawOrigin::Signed(alice.clone()).into(),
 			amount,
 			LockDuration::OneMonth,
@@ -136,7 +136,7 @@ benchmarks! {
 		);
 
 		// she unbonds
-		Pallet::<T>::unbond(
+		let _ = Pallet::<T>::unbond(
 			RawOrigin::Signed(alice.clone()).into(),
 		);
 
@@ -157,7 +157,7 @@ benchmarks! {
 		let amount: BalanceOf<T> = BalanceOf::<T>::from(100_000 * REEF);
 
 		// she makes initial commitment
-		Pallet::<T>::commit(
+		let _ = Pallet::<T>::commit(
 			RawOrigin::Signed(alice.clone()).into(),
 			amount,
 			LockDuration::OneYear,

--- a/modules/poc/src/lib.rs
+++ b/modules/poc/src/lib.rs
@@ -10,7 +10,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{
 		Currency, ReservableCurrency, IsType, WithdrawReasons, ExistenceRequirement,
-		InitializeMembers, ChangeMembers,
+		ChangeMembers,
 	},
 	weights::Weight,
 	ensure,
@@ -19,7 +19,7 @@ use frame_support::{
 use sp_runtime::Perbill;
 use frame_support::sp_runtime::traits::{
 	Zero, Saturating,
-	CheckedAdd, CheckedMul, CheckedDiv
+	CheckedAdd, CheckedDiv
 };
 use frame_system::pallet_prelude::*;
 use sp_std::prelude::*;

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::upper_case_acronyms)]
 
-use codec::{Decode, Encode, FullCodec, HasCompact};
+use codec::{Decode, Encode};
 use frame_support::pallet_prelude::Weight;
 use primitives::evm::{CallInfo, EvmAddress};
 use sp_core::H160;
@@ -12,7 +12,6 @@ use sp_runtime::{
 };
 use sp_std::{
 	cmp::{Eq, PartialEq},
-	fmt::Debug,
 	prelude::*,
 };
 

--- a/modules/transaction_payment/src/lib.rs
+++ b/modules/transaction_payment/src/lib.rs
@@ -23,7 +23,7 @@ use primitives::{Balance, CurrencyId};
 use sp_runtime::{
 	traits::{
 		CheckedSub, Convert, DispatchInfoOf, PostDispatchInfoOf, SaturatedConversion, Saturating, SignedExtension,
-		UniqueSaturatedInto, Zero,
+		Zero,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionValidity, TransactionValidityError, ValidTransaction,
@@ -31,7 +31,7 @@ use sp_runtime::{
 	FixedPointNumber, FixedPointOperand, FixedU128, Perquintill,
 };
 use sp_std::{prelude::*, vec};
-use support::{Ratio, TransactionPayment};
+use support::{TransactionPayment};
 
 mod default_weight;
 mod mock;
@@ -515,7 +515,6 @@ where
 
 	pub fn ensure_can_charge_fee(who: &T::AccountId, fee: PalletBalanceOf<T>, reason: WithdrawReasons) {
 		let native_currency_id = T::NativeCurrencyId::get();
-		let stable_currency_id = T::StableCurrencyId::get();
 		let other_currency_ids = T::AllNonNativeCurrencyIds::get();
 		let mut charge_fee_order: Vec<CurrencyId> =
 			if let Some(default_fee_currency_id) = DefaultFeeCurrencyId::<T>::get(who) {

--- a/modules/transaction_payment/src/mock.rs
+++ b/modules/transaction_payment/src/mock.rs
@@ -70,7 +70,7 @@ impl frame_system::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
 		Default::default()
 	};
 }

--- a/modules/transaction_payment/src/mock.rs
+++ b/modules/transaction_payment/src/mock.rs
@@ -10,10 +10,10 @@ use primitives::{evm::EvmAddress, mocks::MockAddressMapping, Amount, TokenSymbol
 use smallvec::smallvec;
 use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::{
-	testing::Header, traits::IdentityLookup, DispatchError, DispatchResult, FixedPointNumber, ModuleId, Perbill,
+	testing::Header, traits::IdentityLookup, DispatchError, DispatchResult, Perbill,
 };
 use sp_std::cell::RefCell;
-use support::{EVMBridge, InvokeContext, Ratio};
+use support::{EVMBridge, InvokeContext};
 
 pub type AccountId = AccountId32;
 pub type BlockNumber = u64;

--- a/modules/transaction_payment/src/tests.rs
+++ b/modules/transaction_payment/src/tests.rs
@@ -53,6 +53,7 @@ fn charges_fee() {
 				.priority,
 			fee2
 		);
+		use sp_runtime::{traits::{UniqueSaturatedInto}};
 		assert_eq!(
 			Currencies::free_balance(REEF, &ALICE),
 			(100000 - fee - fee2).unique_saturated_into()

--- a/modules/transaction_payment/src/tests.rs
+++ b/modules/transaction_payment/src/tests.rs
@@ -94,7 +94,7 @@ fn charges_fee_when_validate_and_native_is_not_enough() {
 		assert_eq!(<Currencies as MultiCurrency<_>>::free_balance(REEF, &BOB), 0);
 		assert_eq!(<Currencies as MultiCurrency<_>>::free_balance(RUSD, &BOB), 1000);
 
-		let fee = 500 * 2 + 1000; // len * byte + weight
+		let _fee = 500 * 2 + 1000; // len * byte + weight
 		assert_err!(
 			ChargeTransactionPayment::<Runtime>::from(0)
 				.validate(&BOB, CALL2, &INFO, 500),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -3,7 +3,7 @@ use reef_runtime::{
 	AccountId, CurrencyId,
 	BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SudoConfig, SystemConfig,
 	IndicesConfig, EVMConfig, StakingConfig, SessionConfig, AuthorityDiscoveryConfig,
-	WASM_BINARY, Signature,
+	WASM_BINARY,
 	TokenSymbol, TokensConfig, REEF,
 	StakerStatus,
 	ImOnlineId, AuthorityDiscoveryId,
@@ -13,7 +13,7 @@ use reef_runtime::{
 };
 use sp_consensus_babe::AuthorityId as BabeId;
 use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::traits::{Verify, IdentifyAccount};
+use sp_runtime::traits::{IdentifyAccount};
 use sc_service::{ChainType, Properties};
 use sc_telemetry::TelemetryEndpoints;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -47,8 +47,8 @@ pub mod currency {
 	pub const CENTS: Balance = DOLLARS / 100;
 
 	pub const REEF: Balance = DOLLARS;
-	pub const mREEF: Balance = REEF / 1_000;
-	pub const uREEF: Balance = REEF / 1_000_000;
+	pub const MREEF: Balance = REEF / 1_000;
+	pub const UREEF: Balance = REEF / 1_000_000;
 }
 
 /// Time and blocks.

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -13,9 +13,8 @@ use frame_system::limits;
 use primitives::{PRECOMPILE_ADDRESS_START, PREDEPLOY_ADDRESS_START};
 use sp_core::H160;
 use sp_runtime::{
-	traits::{Convert, Saturating},
-	transaction_validity::TransactionPriority,
-	FixedPointNumber, FixedPointOperand, Perbill,
+	traits::{Convert},
+	Perbill,
 	FixedU128
 };
 

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -22,8 +22,6 @@ use sp_runtime::{
 use sp_std::{collections::btree_map::BTreeMap, str::FromStr};
 
 pub type AccountId = AccountId32;
-type Key = CurrencyId;
-pub type Price = FixedU128;
 type Balance = u128;
 
 parameter_types! {
@@ -63,7 +61,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
 		Default::default()
 	};
 }
@@ -266,8 +264,6 @@ impl module_evm::Config for Test {
 }
 
 pub const ALICE: AccountId = AccountId::new([1u8; 32]);
-pub const BOB: AccountId = AccountId::new([2u8; 32]);
-pub const EVA: AccountId = AccountId::new([5u8; 32]);
 
 pub fn alice() -> H160 {
 	H160([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{AllPrecompiles, BlockWeights, Ratio, SystemContractsFilter, Weight};
+use crate::{AllPrecompiles, BlockWeights, SystemContractsFilter, Weight};
 use codec::{Decode, Encode};
 use frame_support::{
 	assert_ok, ord_parameter_types, parameter_types,
@@ -9,7 +9,7 @@ use frame_support::{
 	RuntimeDebug,
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
-use orml_traits::{parameter_type_with_key, MultiReservableCurrency};
+use orml_traits::{parameter_type_with_key};
 pub use primitives::{
 	evm::AddressMapping, mocks::MockAddressMapping,
 	Amount, BlockNumber, CurrencyId, Header, Nonce, TokenSymbol,
@@ -17,7 +17,7 @@ pub use primitives::{
 use sp_core::{crypto::AccountId32, bytes::from_hex, Bytes, H160, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, Convert, IdentityLookup},
-	DispatchResult, FixedPointNumber, FixedU128, ModuleId, Perbill,
+	Perbill,
 };
 use sp_std::{collections::btree_map::BTreeMap, str::FromStr};
 

--- a/runtime/common/src/precompile/tests.rs
+++ b/runtime/common/src/precompile/tests.rs
@@ -3,19 +3,16 @@ use super::*;
 use crate::precompile::{
 	mock::{
 		alice, bob, get_task_id, new_test_ext, run_to_block, Balances, Event as TestEvent,
-		Origin, ScheduleCallPrecompile, System, Test,
-		REEF_ERC20_ADDRESS, ALICE, RUSD,
+		ScheduleCallPrecompile, System, Test,
+		REEF_ERC20_ADDRESS,
 	},
 	schedule_call::TaskInfo,
 };
 use codec::Encode;
-use frame_support::{assert_noop, assert_ok};
 use hex_literal::hex;
 use module_evm::ExitError;
-use orml_traits::DataFeeder;
 use primitives::{evm::AddressMapping, Balance, PREDEPLOY_ADDRESS_START};
-use sp_core::{H160, H256, U256};
-use sp_runtime::FixedPointNumber;
+use sp_core::{H160, U256};
 
 pub struct DummyPrecompile;
 impl Precompile for DummyPrecompile {

--- a/runtime/common/src/precompile/tests.rs
+++ b/runtime/common/src/precompile/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::precompile::{
 	mock::{
 		alice, bob, get_task_id, new_test_ext, run_to_block, Balances, Event as TestEvent,
-		Origin, Price, ScheduleCallPrecompile, System, Test,
+		Origin, ScheduleCallPrecompile, System, Test,
 		REEF_ERC20_ADDRESS, ALICE, RUSD,
 	},
 	schedule_call::TaskInfo,

--- a/runtime/src/benchmarking/utils.rs
+++ b/runtime/src/benchmarking/utils.rs
@@ -1,7 +1,7 @@
-use crate::{AccountId, Balance, Currencies, CurrencyId, Runtime, TokenSymbol, DOLLARS};
+use crate::{AccountId, Balance, Currencies, CurrencyId, TokenSymbol};
 
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
-use sp_runtime::traits::{SaturatedConversion, StaticLookup};
+use sp_runtime::traits::{SaturatedConversion};
 
 pub fn set_balance(currency_id: CurrencyId, who: &AccountId, balance: Balance) {
 	let _ = <Currencies as MultiCurrencyExtended<_>>::update_balance(currency_id, &who, balance.saturated_into());

--- a/runtime/src/benchmarking/utils.rs
+++ b/runtime/src/benchmarking/utils.rs
@@ -3,10 +3,6 @@ use crate::{AccountId, Balance, Currencies, CurrencyId, Runtime, TokenSymbol, DO
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
 use sp_runtime::traits::{SaturatedConversion, StaticLookup};
 
-pub fn lookup_of_account(who: AccountId) -> <<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source {
-	<Runtime as frame_system::Config>::Lookup::unlookup(who)
-}
-
 pub fn set_balance(currency_id: CurrencyId, who: &AccountId, balance: Balance) {
 	let _ = <Currencies as MultiCurrencyExtended<_>>::update_balance(currency_id, &who, balance.saturated_into());
 	assert_eq!(
@@ -15,14 +11,6 @@ pub fn set_balance(currency_id: CurrencyId, who: &AccountId, balance: Balance) {
 	);
 }
 
-pub fn set_rusd_balance(who: &AccountId, balance: Balance) {
-	set_balance(CurrencyId::Token(TokenSymbol::RUSD), who, balance)
-}
-
 pub fn set_reef_balance(who: &AccountId, balance: Balance) {
 	set_balance(CurrencyId::Token(TokenSymbol::REEF), who, balance)
-}
-
-pub fn dollars<T: Into<u128>>(d: T) -> Balance {
-	DOLLARS.saturating_mul(d.into())
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -15,10 +15,10 @@ use sp_core::{
 	H160, OpaqueMetadata, Decode,
 };
 use sp_runtime::{
-	ApplyExtrinsicResult, generic, create_runtime_str, impl_opaque_keys, MultiSignature,
+	ApplyExtrinsicResult, generic, create_runtime_str, impl_opaque_keys,
 	transaction_validity::{TransactionValidity, TransactionSource, TransactionPriority},
 	curve::PiecewiseLinear,
-	FixedPointNumber, ModuleId, MultiAddress,
+	FixedPointNumber,
 };
 use sp_runtime::traits::{
 	BlakeTwo256,
@@ -49,17 +49,10 @@ use sp_version::NativeVersion;
 #[cfg(any(feature = "std", test))]
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_balances::Call as BalancesCall;
-// pub use sp_runtime::BuildStorage;
 pub use frame_support::{
 	construct_runtime, parameter_types, debug,
 	StorageValue,
 	traits::{
-		// Contains,
-		// ContainsLengthBound,
-		// Filter,
-		// Get,
-		// IsType,
-		// LockIdentifier,
 		WithdrawReasons,
 		KeyOwnerProofSystem, Randomness, EnsureOrigin, OriginTrait, U128CurrencyToVote,
 		schedule::Priority,
@@ -73,11 +66,10 @@ pub use frame_system::{ensure_root, EnsureOneOf, EnsureRoot, RawOrigin};
 
 use orml_traits::{parameter_type_with_key};
 use orml_authority::EnsureDelayed;
-// use orml_tokens::CurrencyAdapter;
 
-use module_evm::{CallInfo, CreateInfo, AddressMapping};
+use module_evm::{CallInfo, CreateInfo};
 use module_evm_accounts::EvmAddressMapping;
-use module_currencies::{BasicCurrencyAdapter, Currency};
+use module_currencies::{BasicCurrencyAdapter};
 use module_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 
 // re-exports

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -517,7 +517,7 @@ impl module_currencies::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
 		Zero::zero()
 	};
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -203,7 +203,7 @@ pub mod opaque {
 
 /// Fee-related
 pub mod fee {
-	use super::{Balance, mREEF};
+	use super::{Balance, MREEF};
 	use frame_support::weights::{
 		constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
@@ -226,7 +226,7 @@ pub mod fee {
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			let p = mREEF;
+			let p = MREEF;
 			let q = Balance::from(ExtrinsicBaseWeight::get()); // 125_000_000
 			smallvec![WeightToFeeCoefficient {
 				degree: 1,
@@ -549,7 +549,7 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 10 * mREEF;
+	pub const TransactionByteFee: Balance = 10 * MREEF;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
 	pub MinimumMultiplier:  Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000 as u128);
@@ -602,7 +602,7 @@ parameter_types! {
 	pub const ChainId: u64 = 13939;
 	// 10 REEF minimum storage deposit
 	pub const NewContractExtraBytes: u32 = 10_000;
-	pub const StorageDepositPerByte: Balance = 1 * mREEF;
+	pub const StorageDepositPerByte: Balance = 1 * MREEF;
 	pub const MaxCodeSize: u32 = 60 * 1024;
 	pub NetworkContractSource: H160 = H160::from_low_u64_be(0);
 	pub const DeveloperDeposit: Balance = 1_000 * REEF;

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -166,7 +166,7 @@ fn deploy_contract(account: AccountId) -> Result<H160, DispatchError> {
 
 #[test]
 fn test_authority_module() {
-	const AUTHORITY_ORIGIN_ID: u8 = 10u8;
+	const _AUTHORITY_ORIGIN_ID: u8 = 10u8;
 
 	ExtBuilder::default()
 		.balances(vec![
@@ -179,7 +179,7 @@ fn test_authority_module() {
 		.build()
 		.execute_with(|| {
 			let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
-			let call = Call::Authority(orml_authority::Call::dispatch_as(
+			let _call = Call::Authority(orml_authority::Call::dispatch_as(
 				AuthoritysOriginId::Root,
 				Box::new(ensure_root_call.clone()),
 			));

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -443,13 +443,13 @@ fn test_evm_accounts_module() {
 fn test_evm_module() {
 	ExtBuilder::default()
 		.balances(vec![
-			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * mREEF)),
-			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * mREEF)),
+			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
+			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
 		])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * mREEF));
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * mREEF));
+			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * MREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF));
 
 			let _alice_address = EvmAccounts::eth_address(&alice());
 			let bob_address = EvmAccounts::eth_address(&bob());
@@ -468,16 +468,16 @@ fn test_evm_module() {
 
 			// test EvmAccounts Lookup
 			assert_eq!(Balances::free_balance(alice_account_id()), 999999999999989633000000000000000);
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * mREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF));
 			let to = EvmAccounts::eth_address(&alice());
 			assert_ok!(Currencies::transfer(
 				Origin::signed(bob_account_id()),
 				MultiAddress::Address20(to.0),
 				CurrencyId::Token(TokenSymbol::REEF),
-				amount(10 * uREEF)
+				amount(10 * UREEF)
 			));
 			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999989633000000000000000);
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * mREEF) - amount(10 * uREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF) - amount(10 * UREEF));
 		});
 }
 
@@ -486,13 +486,13 @@ fn test_evm_module() {
 fn test_evm_module() {
 	ExtBuilder::default()
 		.balances(vec![
-			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * mREEF)),
-			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * mREEF)),
+			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
+			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
 		])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * mREEF));
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * mREEF));
+			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * MREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF));
 
 			use std::fs::{self, File};
 			use std::io::Read;

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -3,26 +3,23 @@
 use codec::Encode;
 use frame_support::{
 	assert_noop, assert_ok,
-	traits::{schedule::DispatchTime, Currency, GenesisBuild, OnFinalize, OnInitialize, OriginTrait},
+	traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
-use frame_system::RawOrigin;
 use reef_runtime::{
 	get_all_module_accounts,
 	AccountId, AuthoritysOriginId,
-	Balance, Balances, BlockNumber, Call,
+	Balance, Balances, Call,
 	CurrencyId,
 	Event, EvmAccounts, GetNativeCurrencyId,
-	NativeTokenExistentialDeposit, Origin, OriginCaller,
+	NativeTokenExistentialDeposit, Origin,
 	Perbill, Runtime, System,
-	TokenSymbol, EVM, SevenDays,
+	TokenSymbol, EVM,
 };
-use module_support::{Price, Rate, Ratio};
-use orml_authority::DelayedOrigin;
-use orml_traits::{Change, MultiCurrency};
+use module_support::{Price};
 use sp_io::hashing::keccak_256;
 use sp_runtime::{
-	traits::{AccountIdConversion, BadOrigin},
-	DispatchError, DispatchResult, FixedPointNumber, MultiAddress,
+	traits::{BadOrigin},
+	DispatchError, FixedPointNumber, MultiAddress,
 };
 
 use primitives::currency::*;


### PR DESCRIPTION
First of all, please let me know if I should have done anything differently. I couldn't find rules for making contributions.

## Why?

I recently tried to compile the `reef-node` on my local machine and noticed there are lots of warnings. Most of them were related to trivial stuff like: unused imports, invalid const names, or unused variables. I would love to see this project maintain high quality of code, where one of the requirements is no compilation warnings.

For a starter, I've voluntarily cleaned up the code myself.

## What?

My main objective with this PR is to reduce the warnings to the absolute possible minimum.

If there was a dead/unused code related to warnings, I've decided to remove it rather than leave it commented out. In principle, the less code, the better readability. If there will be a need to use the removed code in the future, we will always can use the version control system to get it back.

---

Ideally there should be no warnings whatsoever. However, for now, there still are a few left to fix for `make test`.

First comes from another repository, so we would have to fix it in our dependency. https://github.com/open-web3-stack/open-runtime-module-library/blob/266768bb90918aab25723ac70ddd93310b378cee/currencies/src/mock.rs#L65

```
warning: unused variable: `currency_id`
  --> orml/currencies/src/mock.rs:65:28
   |
65 |     pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
   |                               ^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_currency_id`
   |
   = note: `#[warn(unused_variables)]` on by default
```

Unfortunately, I use Rust for only a few days and I don't know how to fix the second one.
```
warning: panic message is not a string literal
   --> runtime/src/lib.rs:339:1
    |
339 | / pallet_staking_reward_curve::build! {
340 | |     // 4.5% min, 27.5% max, 50% ideal stake
341 | |     const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
342 | |         min_inflation: 0_045_000,
...   |
348 | |     );
349 | | }
    | |_^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
    = note: the panic!() macro supports formatting, so there's no need for the format!() macro here
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

There is no `panic` usage in this block of the code that compiler complains about. Feel free to leave a suggestion what's wrong here (and how to fix it). 

## What's next?

I would like to propose using GitHub Actions to ensure code quality in the future PRs. It would be helpful not only as a quality check, but more importantly we would know if this project builds correctly (and if tests pass).