### PR TITLE
Makefile: Don't use `--release` for non release targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ release:
 
 .PHONY: build
 build:
-	cargo build --manifest-path node/Cargo.toml --features runtime-benchmarks,with-ethereum-compatibility --release
+	cargo build --manifest-path node/Cargo.toml --features runtime-benchmarks,with-ethereum-compatibility
 
 .PHONY: wasm
 wasm:


### PR DESCRIPTION
Usage of `--release` in non release targets unnecessarily increases the time to build.

```
--release                    Build artifacts in release mode, with optimizations
```

We don't need optimizations in our local builds, do we?
