### PR TITLE
Makefile: Misc improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,4 @@ doc:
 cargo-update:
 	cargo update
 	cargo update --manifest-path node/Cargo.toml
-	make test
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ wasm:
 	cargo build -p reef-runtime --features with-ethereum-compatibility --release
 
 .PHONY: genesis
-genesis:
-	make release
+genesis: release
 	./target/release/reef-node build-spec --chain testnet > assets/chain_spec_testnet.json
 	./target/release/reef-node build-spec --chain mainnet > assets/chain_spec_mainnet.json
 

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,9 @@ init:
 .PHONY: release
 release:
 	rustup install 1.51.0
-	rustup default 1.51.0
+	rustup default 1.51.0  # TODO: Do not set the default toolchain here (it's obscure and super unexpected).
 	rustup toolchain install nightly-2021-05-09
 	rustup target add wasm32-unknown-unknown --toolchain nightly-2021-05-09
-	rm -rf target/
 	cargo build --manifest-path node/Cargo.toml --features with-ethereum-compatibility --release
 
 .PHONY: build


### PR DESCRIPTION
Firstly, I would like to propose that we don't change the default toolchain in the `make release` command. It is an unexpected behaviour with no information about this side effect. For now, I left TODO to fix it later.
However, if you know how to use a specific toolchain for `cargo build`, then we could do it within this PR.

Secondly, in my opinion `release` target should not delete whole `target` project. It will be a common scenario that developers use `debug` targets which would be completely removed if one would run `release` target. I personally would be rather unhappy to wait another half an hour again to compile everything once again.

Thirdly, we should use the built-in dependencies functionality rather than exec targets as commands (i.e. syntax: `target: dependency`).