### PR TITLE
Add `make clippy` job to GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,4 +26,12 @@ jobs:
       run: make init
     - name: Test
       run: make test
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Init
+      run: make init
+    - name: Clippy
+      run: make clippy
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check:
 
 .PHONY: clippy
 clippy:
-	SKIP_WASM_BUILD=1 cargo clippy
+	SKIP_WASM_BUILD=1 cargo clippy -- -D warnings -A clippy::from-over-into -A clippy::type-complexity -A clippy::unnecessary-cast -A clippy::identity-op
 
 .PHONY: watch
 watch:

--- a/modules/poc/src/lib.rs
+++ b/modules/poc/src/lib.rs
@@ -193,7 +193,7 @@ pub mod module {
 	#[pallet::type_value]
 	pub(super) fn FirstEra<T: Config>() -> Era<T::BlockNumber> {
 		Era {
-			index: (0 as u32).into(),
+			index: (0 as u32),
 			start: (0 as u32).into(),
 		}
 	}
@@ -393,9 +393,9 @@ pub mod module {
 
 			// create a new commitment
 			<Commitments<T>>::insert(&origin, Commitment {
-				amount: amount,
-				duration: duration,
-				candidate: candidate,
+				duration,
+				amount,
+				candidate,
 				..Default::default()
 			});
 			Self::deposit_event(Event::Committed(origin, amount));
@@ -566,8 +566,7 @@ impl<T: Config> Pallet<T> {
 	pub fn era_council_rewards() -> BalanceOf<T> {
 		let total_supply = T::Currency::total_issuance();
 		let council_apy = T::CouncilInflation::get() * total_supply;
-		let era_reward = Self::proportion_of_era_to_year() * council_apy;
-		era_reward
+		Self::proportion_of_era_to_year() * council_apy
 	}
 
 	/// example: 7/365

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,7 @@ use sp_core::{Pair, Public, sr25519, H160, Bytes};
 use reef_runtime::{
 	AccountId, CurrencyId,
 	BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SudoConfig, SystemConfig,
-	IndicesConfig, EVMConfig, StakingConfig, SessionConfig, AuthorityDiscoveryConfig,
+	IndicesConfig, EvmConfig, StakingConfig, SessionConfig, AuthorityDiscoveryConfig,
 	WASM_BINARY,
 	TokenSymbol, TokensConfig, REEF,
 	StakerStatus,
@@ -52,7 +52,7 @@ fn get_session_keys(
 	im_online: ImOnlineId,
 	authority_discovery: AuthorityDiscoveryId,
 	) -> SessionKeys {
-	SessionKeys { grandpa, babe, im_online, authority_discovery }
+	SessionKeys { babe, grandpa, im_online, authority_discovery }
 }
 
 /// Helper function to generate a crypto pair from seed
@@ -398,7 +398,7 @@ fn testnet_genesis(
 				})
 				.collect(),
 		}),
-		module_evm: Some(EVMConfig {
+		module_evm: Some(EvmConfig {
 			accounts: evm_genesis_accounts,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key }),
@@ -483,7 +483,7 @@ fn mainnet_genesis(
 		orml_tokens: Some(TokensConfig {
 			endowed_accounts: vec![]
 		}),
-		module_evm: Some(EVMConfig {
+		module_evm: Some(EvmConfig {
 			accounts: evm_genesis_accounts,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key }),

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -48,7 +48,7 @@ pub mod currency {
 
 	pub const REEF: Balance = DOLLARS;
 	pub const MILLI_REEF: Balance = REEF / 1_000;
-	pub const UREEF: Balance = REEF / 1_000_000;
+	pub const MICRO_REEF: Balance = REEF / 1_000_000;
 }
 
 /// Time and blocks.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -47,7 +47,7 @@ pub mod currency {
 	pub const CENTS: Balance = DOLLARS / 100;
 
 	pub const REEF: Balance = DOLLARS;
-	pub const MREEF: Balance = REEF / 1_000;
+	pub const MILLI_REEF: Balance = REEF / 1_000;
 	pub const UREEF: Balance = REEF / 1_000_000;
 }
 

--- a/runtime/src/benchmarking/evm.rs
+++ b/runtime/src/benchmarking/evm.rs
@@ -1,4 +1,4 @@
-use crate::{AccountId, Balance, Event, EvmAccounts, Origin, Runtime, System, DOLLARS, EVM};
+use crate::{AccountId, Balance, Event, EvmAccounts, Origin, Runtime, System, DOLLARS, Evm};
 
 use super::utils::set_reef_balance;
 use frame_support::dispatch::DispatchError;
@@ -37,7 +37,7 @@ fn deploy_contract(caller: AccountId) -> Result<H160, DispatchError> {
 	let contract = hex_literal::hex!("608060405234801561001057600080fd5b5061016f806100206000396000f3fe608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063412a5a6d14610046575b600080fd5b61004e610050565b005b600061005a6100e2565b604051809103906000f080158015610076573d6000803e3d6000fd5b50905060008190806001815401808255809150509060018203906000526020600020016000909192909190916101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505050565b6040516052806100f28339019056fe6080604052348015600f57600080fd5b50603580601d6000396000f3fe6080604052600080fdfea165627a7a7230582092dc1966a8880ddf11e067f9dd56a632c11a78a4afd4a9f05924d427367958cc0029a165627a7a723058202b2cc7384e11c452cdbf39b68dada2d5e10a632cc0174a354b8b8c83237e28a40029").to_vec();
 
 	System::set_block_number(1);
-	EVM::create(Origin::signed(caller), contract, 0, 1000000000, 1000000000)
+	Evm::create(Origin::signed(caller), contract, 0, 1000000000, 1000000000)
 		.map_or_else(|e| Err(e.error), |_| Ok(()))?;
 
 	if let Event::module_evm(module_evm::Event::Created(address)) = System::events().iter().last().unwrap().event {
@@ -93,7 +93,7 @@ runtime_benchmarks! {
 
 	disable_contract_development {
 		set_reef_balance(&alice_account_id(), dollar(1000));
-		EVM::enable_contract_development(Origin::signed(alice_account_id()))?;
+		Evm::enable_contract_development(Origin::signed(alice_account_id()))?;
 	}: _(RawOrigin::Signed(alice_account_id()))
 
 	set_code {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -191,7 +191,7 @@ pub mod opaque {
 
 /// Fee-related
 pub mod fee {
-	use super::{Balance, MREEF};
+	use super::{Balance, MILLI_REEF};
 	use frame_support::weights::{
 		constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
@@ -214,7 +214,7 @@ pub mod fee {
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			let p = MREEF;
+			let p = MILLI_REEF;
 			let q = Balance::from(ExtrinsicBaseWeight::get()); // 125_000_000
 			smallvec![WeightToFeeCoefficient {
 				degree: 1,
@@ -537,7 +537,7 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 10 * MREEF;
+	pub const TransactionByteFee: Balance = 10 * MILLI_REEF;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
 	pub MinimumMultiplier:  Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000 as u128);
@@ -590,7 +590,7 @@ parameter_types! {
 	pub const ChainId: u64 = 13939;
 	// 10 REEF minimum storage deposit
 	pub const NewContractExtraBytes: u32 = 10_000;
-	pub const StorageDepositPerByte: Balance = 1 * MREEF;
+	pub const StorageDepositPerByte: Balance = 1 * MILLI_REEF;
 	pub const MaxCodeSize: u32 = 60 * 1024;
 	pub NetworkContractSource: H160 = H160::from_low_u64_be(0);
 	pub const DeveloperDeposit: Balance = 1_000 * REEF;

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -440,13 +440,13 @@ fn test_evm_accounts_module() {
 fn test_evm_module() {
 	ExtBuilder::default()
 		.balances(vec![
-			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
-			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
+			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MILLI_REEF)),
+			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MILLI_REEF)),
 		])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * MREEF));
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF));
+			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * MILLI_REEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF));
 
 			let _alice_address = EvmAccounts::eth_address(&alice());
 			let bob_address = EvmAccounts::eth_address(&bob());
@@ -465,7 +465,7 @@ fn test_evm_module() {
 
 			// test EvmAccounts Lookup
 			assert_eq!(Balances::free_balance(alice_account_id()), 999999999999989633000000000000000);
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF));
 			let to = EvmAccounts::eth_address(&alice());
 			assert_ok!(Currencies::transfer(
 				Origin::signed(bob_account_id()),
@@ -474,7 +474,7 @@ fn test_evm_module() {
 				amount(10 * UREEF)
 			));
 			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999989633000000000000000);
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF) - amount(10 * UREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF) - amount(10 * UREEF));
 		});
 }
 
@@ -483,13 +483,13 @@ fn test_evm_module() {
 fn test_evm_module() {
 	ExtBuilder::default()
 		.balances(vec![
-			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
-			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MREEF)),
+			(alice_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MILLI_REEF)),
+			(bob_account_id(), CurrencyId::Token(TokenSymbol::REEF), amount(1 * MILLI_REEF)),
 		])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * MREEF));
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MREEF));
+			assert_eq!(Balances::free_balance(alice_account_id()), amount(1 * MILLI_REEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF));
 
 			use std::fs::{self, File};
 			use std::io::Read;

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -13,7 +13,7 @@ use reef_runtime::{
 	Event, EvmAccounts, GetNativeCurrencyId,
 	NativeTokenExistentialDeposit, Origin,
 	Perbill, Runtime, System,
-	TokenSymbol, EVM,
+	TokenSymbol, Evm,
 };
 use module_support::{Price};
 use sp_io::hashing::keccak_256;
@@ -153,7 +153,7 @@ fn deploy_contract(account: AccountId) -> Result<H160, DispatchError> {
 	// contract Contract {}
 	let contract = hex_literal::hex!("608060405234801561001057600080fd5b5061016f806100206000396000f3fe608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063412a5a6d14610046575b600080fd5b61004e610050565b005b600061005a6100e2565b604051809103906000f080158015610076573d6000803e3d6000fd5b50905060008190806001815401808255809150509060018203906000526020600020016000909192909190916101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505050565b6040516052806100f28339019056fe6080604052348015600f57600080fd5b50603580601d6000396000f3fe6080604052600080fdfea165627a7a7230582092dc1966a8880ddf11e067f9dd56a632c11a78a4afd4a9f05924d427367958cc0029a165627a7a723058202b2cc7384e11c452cdbf39b68dada2d5e10a632cc0174a354b8b8c83237e28a40029").to_vec();
 
-	EVM::create(Origin::signed(account), contract, 0, 1000000000, 1000000000)
+	Evm::create(Origin::signed(account), contract, 0, 1000000000, 1000000000)
 		.map_or_else(|e| Err(e.error), |_| Ok(()))?;
 
 	if let Event::module_evm(module_evm::Event::Created(address)) = System::events().iter().last().unwrap().event {
@@ -455,7 +455,7 @@ fn test_evm_module() {
 			let event = Event::module_evm(module_evm::Event::Created(contract));
 			assert_eq!(last_event(), event);
 
-			assert_ok!(EVM::transfer_maintainer(
+			assert_ok!(Evm::transfer_maintainer(
 				Origin::signed(alice_account_id()),
 				contract,
 				bob_address
@@ -510,7 +510,7 @@ fn test_evm_module() {
 				let bytecode_str = bytecode_str.replace("\"", "");
 
 				let bytecode = hex::decode(bytecode_str).unwrap();
-				assert_ok!(EVM::create(
+				assert_ok!(Evm::create(
 					Origin::signed(alice_account_id()),
 					bytecode,
 					0,

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -471,10 +471,10 @@ fn test_evm_module() {
 				Origin::signed(bob_account_id()),
 				MultiAddress::Address20(to.0),
 				CurrencyId::Token(TokenSymbol::REEF),
-				amount(10 * UREEF)
+				amount(10 * MICRO_REEF)
 			));
 			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999989633000000000000000);
-			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF) - amount(10 * UREEF));
+			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF) - amount(10 * MICRO_REEF));
 		});
 }
 


### PR DESCRIPTION
Additionally, I enabled treating clippy warnings as errors, so that CI will fail if something is wrong. Of course, I had to fix the source code, so that CI will pass and we don't merge anything that doesn't build to `master`.

Please, do a proper review of my PR as I had to introduce more changes at some parts of the code (more than I would like to). All of them were because of a failing `make clippy` run (`clippy` complained). (Feel free to double check by reverting my changes and running `make clippy` on your own.)

Moreover, we could tweak the `clippy` target. I am not sure if treating all warnings as errors is the way to go. For instance, I would say that `1 * REEF` looks fine, but I didn't exclude it because it is already in the 'standard' set of warnings.