### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.51.0 as build
+
+RUN rustup default nightly-2021-05-09
+RUN apt-get update && apt-get install -y clang
+
+WORKDIR /build
+COPY . /build
+RUN make release
+
+FROM debian:buster
+
+COPY --from=build /build/target/release/reef-node /usr/local/bin
+ENTRYPOINT ["reef-node"]


### PR DESCRIPTION
Add a basic Dockerfile that should simplify node deployment. Doing this will be as simple as running:

```
# docker run reef-node --chain mainnet [...]
```

Build is split into two stages in order to minimize final image size.