### PR TITLE
GitHub Actions: Fix cache indentation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-      key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Init
       run: make init
     - name: Build
@@ -39,7 +39,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-      key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Init
       run: make init
     - name: Test


### PR DESCRIPTION
It fixes running Workflows as current definition is invalid due to recently added cache.

Additionally, I would like to propose enabling a requirement for passing checks to merge a PR.
![image](https://user-images.githubusercontent.com/908744/121436297-9c49a100-c980-11eb-9abe-f1a9c48115b8.png)
