### PR TITLE
GitHub Actions: Add cache for `clippy` job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: build-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Init
       run: make init
     - name: Build
@@ -39,7 +39,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Init
       run: make init
     - name: Test
@@ -56,7 +56,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: clippy-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Init
       run: make init
     - name: Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,8 +48,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Init
       run: make init
     - name: Clippy
       run: make clippy
-


### PR DESCRIPTION
Cache in the Workflow was introduced at the same time as the (new) `clippy` job, therefore the original `clippy` PR didn't include the newly proposed caching step. This PR makes it right by applying the same caching strategy for the `clippy` job.

