### PR TITLE
revert evm pallet name from Evm back to EVM

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,7 @@ use sp_core::{Pair, Public, sr25519, H160, Bytes};
 use reef_runtime::{
 	AccountId, CurrencyId,
 	BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SudoConfig, SystemConfig,
-	IndicesConfig, EvmConfig, StakingConfig, SessionConfig, AuthorityDiscoveryConfig,
+	IndicesConfig, EVMConfig, StakingConfig, SessionConfig, AuthorityDiscoveryConfig,
 	WASM_BINARY,
 	TokenSymbol, TokensConfig, REEF,
 	StakerStatus,
@@ -407,7 +407,7 @@ fn testnet_genesis(
 				})
 				.collect(),
 		}),
-		module_evm: Some(EvmConfig {
+		module_evm: Some(EVMConfig {
 			accounts: evm_genesis_accounts,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key }),
@@ -492,7 +492,7 @@ fn mainnet_genesis(
 		orml_tokens: Some(TokensConfig {
 			endowed_accounts: vec![]
 		}),
-		module_evm: Some(EvmConfig {
+		module_evm: Some(EVMConfig {
 			accounts: evm_genesis_accounts,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key }),

--- a/runtime/src/benchmarking/evm.rs
+++ b/runtime/src/benchmarking/evm.rs
@@ -1,4 +1,4 @@
-use crate::{AccountId, Balance, Event, EvmAccounts, Origin, Runtime, System, DOLLARS, Evm};
+use crate::{AccountId, Balance, Event, EvmAccounts, Origin, Runtime, System, DOLLARS, EVM};
 
 use super::utils::set_reef_balance;
 use frame_support::dispatch::DispatchError;
@@ -37,7 +37,7 @@ fn deploy_contract(caller: AccountId) -> Result<H160, DispatchError> {
 	let contract = hex_literal::hex!("608060405234801561001057600080fd5b5061016f806100206000396000f3fe608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063412a5a6d14610046575b600080fd5b61004e610050565b005b600061005a6100e2565b604051809103906000f080158015610076573d6000803e3d6000fd5b50905060008190806001815401808255809150509060018203906000526020600020016000909192909190916101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505050565b6040516052806100f28339019056fe6080604052348015600f57600080fd5b50603580601d6000396000f3fe6080604052600080fdfea165627a7a7230582092dc1966a8880ddf11e067f9dd56a632c11a78a4afd4a9f05924d427367958cc0029a165627a7a723058202b2cc7384e11c452cdbf39b68dada2d5e10a632cc0174a354b8b8c83237e28a40029").to_vec();
 
 	System::set_block_number(1);
-	Evm::create(Origin::signed(caller), contract, 0, 1000000000, 1000000000)
+	EVM::create(Origin::signed(caller), contract, 0, 1000000000, 1000000000)
 		.map_or_else(|e| Err(e.error), |_| Ok(()))?;
 
 	if let Event::module_evm(module_evm::Event::Created(address)) = System::events().iter().last().unwrap().event {
@@ -93,7 +93,7 @@ runtime_benchmarks! {
 
 	disable_contract_development {
 		set_reef_balance(&alice_account_id(), dollar(1000));
-		Evm::enable_contract_development(Origin::signed(alice_account_id()))?;
+		EVM::enable_contract_development(Origin::signed(alice_account_id()))?;
 	}: _(RawOrigin::Signed(alice_account_id()))
 
 	set_code {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -230,8 +230,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("reef"),
 	impl_name: create_runtime_str!("reef"),
 	authoring_version: 1,
-	spec_version: 6,
-	impl_version: 6,
+	spec_version: 7,
+	impl_version: 7,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };
@@ -599,7 +599,7 @@ parameter_types! {
 
 pub type MultiCurrencyPrecompile =
 	runtime_common::MultiCurrencyPrecompile<AccountId, EvmAddressMapping<Runtime>, Currencies>;
-pub type StateRentPrecompile = runtime_common::StateRentPrecompile<AccountId, EvmAddressMapping<Runtime>, Evm>;
+pub type StateRentPrecompile = runtime_common::StateRentPrecompile<AccountId, EvmAddressMapping<Runtime>, EVM>;
 pub type ScheduleCallPrecompile = runtime_common::ScheduleCallPrecompile<
 	AccountId,
 	EvmAddressMapping<Runtime>,
@@ -642,7 +642,7 @@ impl module_evm::Config for Runtime {
 }
 
 impl module_evm_bridge::Config for Runtime {
-	type EVM = Evm;
+	type EVM = EVM;
 }
 
 parameter_types! {
@@ -789,7 +789,7 @@ construct_runtime!(
 
 		// Smart contracts
 		EvmAccounts: module_evm_accounts::{Module, Call, Storage, Event<T>} = 20,
-		Evm: module_evm::{Module, Config<T>, Call, Storage, Event<T>} = 21,
+		EVM: module_evm::{Module, Config<T>, Call, Storage, Event<T>} = 21,
 		EVMBridge: module_evm_bridge::{Module} = 22,
 
 		// Consensus
@@ -1137,7 +1137,7 @@ impl_runtime_apis! {
 				.map_err(|_| sp_runtime::DispatchError::Other("Invalid parameter extrinsic, decode failed"))?;
 
 			let request = match utx.function {
-				Call::Evm(module_evm::Call::call(to, data, value, gas_limit, storage_limit)) => {
+				Call::EVM(module_evm::Call::call(to, data, value, gas_limit, storage_limit)) => {
 					Some(EstimateResourcesRequest {
 						from: None,
 						to: Some(to),
@@ -1147,7 +1147,7 @@ impl_runtime_apis! {
 						data: Some(data),
 					})
 				}
-				Call::Evm(module_evm::Call::create(data, value, gas_limit, storage_limit)) => {
+				Call::EVM(module_evm::Call::create(data, value, gas_limit, storage_limit)) => {
 					Some(EstimateResourcesRequest {
 						from: None,
 						to: None,

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -13,7 +13,7 @@ use reef_runtime::{
 	Event, EvmAccounts, GetNativeCurrencyId,
 	NativeTokenExistentialDeposit, Origin,
 	Perbill, Runtime, System,
-	TokenSymbol, Evm,
+	TokenSymbol, EVM,
 };
 use module_support::{Price};
 use sp_io::hashing::keccak_256;
@@ -153,7 +153,7 @@ fn deploy_contract(account: AccountId) -> Result<H160, DispatchError> {
 	// contract Contract {}
 	let contract = hex_literal::hex!("608060405234801561001057600080fd5b5061016f806100206000396000f3fe608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063412a5a6d14610046575b600080fd5b61004e610050565b005b600061005a6100e2565b604051809103906000f080158015610076573d6000803e3d6000fd5b50905060008190806001815401808255809150509060018203906000526020600020016000909192909190916101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505050565b6040516052806100f28339019056fe6080604052348015600f57600080fd5b50603580601d6000396000f3fe6080604052600080fdfea165627a7a7230582092dc1966a8880ddf11e067f9dd56a632c11a78a4afd4a9f05924d427367958cc0029a165627a7a723058202b2cc7384e11c452cdbf39b68dada2d5e10a632cc0174a354b8b8c83237e28a40029").to_vec();
 
-	Evm::create(Origin::signed(account), contract, 0, 1000000000, 1000000000)
+	EVM::create(Origin::signed(account), contract, 0, 1000000000, 1000000000)
 		.map_or_else(|e| Err(e.error), |_| Ok(()))?;
 
 	if let Event::module_evm(module_evm::Event::Created(address)) = System::events().iter().last().unwrap().event {
@@ -455,7 +455,7 @@ fn test_evm_module() {
 			let event = Event::module_evm(module_evm::Event::Created(contract));
 			assert_eq!(last_event(), event);
 
-			assert_ok!(Evm::transfer_maintainer(
+			assert_ok!(EVM::transfer_maintainer(
 				Origin::signed(alice_account_id()),
 				contract,
 				bob_address
@@ -510,7 +510,7 @@ fn test_evm_module() {
 				let bytecode_str = bytecode_str.replace("\"", "");
 
 				let bytecode = hex::decode(bytecode_str).unwrap();
-				assert_ok!(Evm::create(
+				assert_ok!(EVM::create(
 					Origin::signed(alice_account_id()),
 					bytecode,
 					0,


### PR DESCRIPTION
This PR addresses #43 in which a contract was created at a seemingly already used address.  The issue is caused due to the fact that storage uses the pallet name to compute storage key hashes.  Hence when the pallet name was changed from EVM to Evm the runtime computed different storage keys for the EVM pallet, in essence creating completely new storage entries.  This PR reverts the pallet name from Evm back to EVM as it was originally.  This will recover the EVM state prior to the v6 upgrade at block 1077077.  Any EVM state changes between 1077077 and when this runtime is deployed to testnet will be lost. 

As part of this PR the runtime has been bumped to v7.