### PR TITLE
Init v9

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -819,47 +819,6 @@ construct_runtime!(
 	}
 );
 
-// Storage migrations required for runtime upgrade v7 -> v8
-/// Babe config migration
-impl pallet_babe::migrations::BabePalletPrefix for Runtime {
-	fn pallet_prefix() -> &'static str {
-		"Babe"
-	}
-}
-
-pub struct BabeEpochConfigMigrations;
-impl frame_support::traits::OnRuntimeUpgrade for BabeEpochConfigMigrations {
-	fn on_runtime_upgrade() -> Weight {
-		log::info!("Migrating Babe pallet - adding epoch config");
-		pallet_babe::migrations::add_epoch_configuration::<Runtime>(
-			BABE_GENESIS_EPOCH_CONFIG
-		)
-	}
-}
-
-/// Migrate from `PalletVersion` to the new `StorageVersion`
-pub struct MigratePalletVersionToStorageVersion;
-impl frame_support::traits::OnRuntimeUpgrade for MigratePalletVersionToStorageVersion {
-	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		log::info!("Migrating PalletVersion to new StorageVersion pattern");
-		frame_support::migrations::migrate_from_pallet_version_to_storage_version::<AllPalletsWithSystem>(
-				&RocksDbWeight::get()
-		)
-	}
-}
-
-/// Migrate staking
-pub struct MigratePalletStakingV5toV7;
-impl frame_support::traits::OnRuntimeUpgrade for MigratePalletStakingV5toV7 {
-	fn on_runtime_upgrade() -> Weight {
-		log::info!("Migrating staking from V5 to V7");
-		let mut weight = 0;
-		weight += pallet_staking::migrations::v6::migrate::<Runtime>();
-		weight += pallet_staking::migrations::v7::migrate::<Runtime>();
-		weight
-	}
-}
-
 /// The address format for describing accounts.
 pub type Address = sp_runtime::MultiAddress<AccountId, AccountIndex>;
 /// Block header type as expected by this runtime.
@@ -894,7 +853,6 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
-	(BabeEpochConfigMigrations, MigratePalletVersionToStorageVersion, MigratePalletStakingV5toV7)
 >;
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -231,8 +231,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("reef"),
 	impl_name: create_runtime_str!("reef"),
 	authoring_version: 1,
-	spec_version: 8,
-	impl_version: 8,
+	spec_version: 9,
+	impl_version: 9,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };


### PR DESCRIPTION
This PR removes redundant storage migrations that were required for v7 -> v8 upgrade and bumps spec version to 9.