### PR TITLE
standardise storage cost per byte

### DIFF
--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -411,7 +411,7 @@ pub mod module {
 				Pallet::<T>::deposit_event(Event::<T>::ExecutedFailed(target, info.exit_reason, info.output));
 			}
 
-			Self::process_queued_events();
+			Self::process_queued_events()?;
 
 			let used_gas: u64 = info.used_gas.unique_saturated_into();
 
@@ -470,7 +470,7 @@ pub mod module {
 				}
 			}
 
-			Self::process_queued_events();
+			Self::process_queued_events()?;
 
 			Ok(PostDispatchInfo {
 				actual_weight: Some(T::GasToWeight::convert(used_gas)),
@@ -497,7 +497,7 @@ pub mod module {
 				Pallet::<T>::deposit_event(Event::<T>::CreatedFailed(info.address, info.exit_reason, info.output));
 			}
 
-			Self::process_queued_events();
+			Self::process_queued_events()?;
 
 			let used_gas: u64 = info.used_gas.unique_saturated_into();
 
@@ -526,7 +526,7 @@ pub mod module {
 				Pallet::<T>::deposit_event(Event::<T>::CreatedFailed(info.address, info.exit_reason, info.output));
 			}
 
-			Self::process_queued_events();
+			Self::process_queued_events()?;
 
 			let used_gas: u64 = info.used_gas.unique_saturated_into();
 
@@ -559,7 +559,7 @@ pub mod module {
 				Pallet::<T>::deposit_event(Event::<T>::CreatedFailed(info.address, info.exit_reason, info.output));
 			}
 
-			Self::process_queued_events();
+			Self::process_queued_events()?;
 
 			let used_gas: u64 = info.used_gas.unique_saturated_into();
 
@@ -680,12 +680,11 @@ impl<T: Config> Pallet<T> {
 	/// Process queued events
 	pub fn process_queued_events() -> DispatchResult {
 		for event in Self::queued_events() {
-			match event {
-				Event::<T>::ContractSelfdestructed(contract, caller) => {
+
+			if let Event::<T>::ContractSelfdestructed(contract, caller) = event {
 					Self::remove_contract(&caller, &contract)?;
-				},
-				_ => {}
-			}
+			};
+
 			Pallet::<T>::deposit_event(event);
 		}
 		QueuedEvents::<T>::kill();
@@ -925,7 +924,7 @@ impl<T: Config> Pallet<T> {
 				}
 			});
 
-			let contract_account_id = T::AddressMapping::get_account_id(&contract);
+			let contract_account_id = T::AddressMapping::get_account_id(contract);
 			T::Currency::unreserve(
 				&contract_account_id,
 				T::Currency::reserved_balance(&contract_account_id),

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -679,7 +679,7 @@ pub mod module {
 impl<T: Config> Pallet<T> {
 	/// Process queued events
 	pub fn process_queued_events() -> DispatchResult {
-		for event in Self::queued_events() {
+		for event in Self::queued_events().drain(..) {
 
 			if let Event::<T>::ContractSelfdestructed(contract, caller) = event {
 					Self::remove_contract(&caller, &contract)?;
@@ -687,7 +687,6 @@ impl<T: Config> Pallet<T> {
 
 			Pallet::<T>::deposit_event(event);
 		}
-		QueuedEvents::<T>::kill();
 
 		Ok(())
 	}

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -383,6 +383,7 @@ pub mod module {
 		/// Issue an EVM call operation. This is similar to a message call
 		/// transaction in Ethereum.
 		#[pallet::weight(T::GasToWeight::convert(*gas_limit))]
+		#[transactional]
 		pub fn call(
 			origin: OriginFor<T>,
 			target: EvmAddress,
@@ -481,6 +482,7 @@ pub mod module {
 		/// Issue an EVM create operation. This is similar to a contract
 		/// creation transaction in Ethereum.
 		#[pallet::weight(T::GasToWeight::convert(*gas_limit))]
+		#[transactional]
 		pub fn create(
 			origin: OriginFor<T>,
 			init: Vec<u8>,
@@ -509,6 +511,7 @@ pub mod module {
 
 		/// Issue an EVM create2 operation.
 		#[pallet::weight(T::GasToWeight::convert(*gas_limit))]
+		#[transactional]
 		pub fn create2(
 			origin: OriginFor<T>,
 			init: Vec<u8>,
@@ -539,6 +542,7 @@ pub mod module {
 		/// Issue an EVM create operation. The next available system contract
 		/// address will be used as created contract address.
 		#[pallet::weight(T::GasToWeight::convert(*gas_limit))]
+		#[transactional]
 		pub fn create_network_contract(
 			origin: OriginFor<T>,
 			init: Vec<u8>,
@@ -906,8 +910,9 @@ impl<T: Config> Pallet<T> {
 		Self::remove_contract(caller, &contract)
 	}
 
+	#[transactional]
 	fn remove_contract(caller: &EvmAddress, contract: &EvmAddress) -> DispatchResult {
-		Accounts::<T>::mutate_exists(contract, |account_info| -> DispatchResult {
+		Accounts::<T>::try_mutate_exists(contract, |account_info| -> DispatchResult {
 			let account_info = account_info.as_mut().ok_or(Error::<T>::ContractNotFound)?;
 			let contract_info = account_info.contract_info.take().ok_or(Error::<T>::ContractNotFound)?;
 

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -678,17 +678,19 @@ pub mod module {
 
 impl<T: Config> Pallet<T> {
 	/// Process queued events
-	pub fn process_queued_events() {
+	pub fn process_queued_events() -> DispatchResult {
 		for event in Self::queued_events() {
 			match event {
 				Event::<T>::ContractSelfdestructed(contract, caller) => {
-					Self::remove_contract(&caller, &contract);
+					Self::remove_contract(&caller, &contract)?;
 				},
 				_ => {}
 			}
 			Pallet::<T>::deposit_event(event);
 		}
 		QueuedEvents::<T>::kill();
+
+		Ok(())
 	}
 
 	/// Remove an account.

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -340,8 +340,8 @@ pub mod module {
 		ContractDeployed(EvmAddress),
 		/// Set contract code. \[contract\]
 		ContractSetCode(EvmAddress),
-		/// Selfdestructed contract code. \[contract\]
-		ContractSelfdestructed(EvmAddress),
+		/// Selfdestructed contract code. \[contract, address\]
+		ContractSelfdestructed(EvmAddress, EvmAddress),
 	}
 
 	#[pallet::error]
@@ -666,10 +666,10 @@ pub mod module {
 		#[transactional]
 		pub fn selfdestruct(origin: OriginFor<T>, contract: EvmAddress) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			let maintainer = T::AddressMapping::get_evm_address(&who).ok_or(Error::<T>::AddressNotMapped)?;
-			Self::do_selfdestruct(who, &maintainer, contract)?;
+			let caller = T::AddressMapping::get_evm_address(&who).ok_or(Error::<T>::AddressNotMapped)?;
+			Self::do_selfdestruct(&caller, contract)?;
 
-			Pallet::<T>::deposit_event(Event::<T>::ContractSelfdestructed(contract));
+			Pallet::<T>::deposit_event(Event::<T>::ContractSelfdestructed(contract, caller));
 
 			Ok(().into())
 		}
@@ -681,6 +681,13 @@ impl<T: Config> Pallet<T> {
 	pub fn process_queued_events() {
 		for event in Self::queued_events() {
 			Pallet::<T>::deposit_event(event);
+
+			// match event {
+			// 	Event::<T>::ContractSelfdestructed(*EvmAddress) => {
+			//
+			// 	},
+			// 	_ => {}
+			// }
 		}
 		QueuedEvents::<T>::kill();
 	}
@@ -887,16 +894,23 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	fn do_selfdestruct(who: T::AccountId, maintainer: &EvmAddress, contract: EvmAddress) -> DispatchResult {
-		Accounts::<T>::mutate_exists(contract, |maybe_account_info| -> DispatchResult {
-			let account_info = maybe_account_info.take().ok_or(Error::<T>::ContractNotFound)?;
-			let contract_info = account_info
-				.contract_info
-				.as_ref()
-				.ok_or(Error::<T>::ContractNotFound)?;
+	fn do_selfdestruct(caller: &EvmAddress, contract: EvmAddress) -> DispatchResult {
+		let account_info = Self::accounts(contract).ok_or(Error::<T>::ContractNotFound)?;
+		let contract_info = account_info
+			.contract_info
+			.as_ref()
+			.ok_or(Error::<T>::ContractNotFound)?;
 
-			ensure!(contract_info.maintainer == *maintainer, Error::<T>::NoPermission);
-			ensure!(!contract_info.deployed, Error::<T>::ContractAlreadyDeployed);
+		ensure!(contract_info.maintainer == *caller, Error::<T>::NoPermission);
+		ensure!(!contract_info.deployed, Error::<T>::ContractAlreadyDeployed);
+
+		Self::remove_contract(caller, &contract)
+	}
+
+	fn remove_contract(caller: &EvmAddress, contract: &EvmAddress) -> DispatchResult {
+		Accounts::<T>::mutate_exists(contract, |account_info| -> DispatchResult {
+			let account_info = account_info.as_mut().ok_or(Error::<T>::ContractNotFound)?;
+			let contract_info = account_info.contract_info.take().ok_or(Error::<T>::ContractNotFound)?;
 
 			AccountStorages::<T>::remove_prefix(contract, None);
 
@@ -915,6 +929,7 @@ impl<T: Config> Pallet<T> {
 				&contract_account_id,
 				T::Currency::reserved_balance(&contract_account_id),
 			);
+			let who = T::AddressMapping::get_account_id(caller);
 			T::TransferAll::transfer_all(&contract_account_id, &who)?;
 
 			Ok(())

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -680,14 +680,13 @@ impl<T: Config> Pallet<T> {
 	/// Process queued events
 	pub fn process_queued_events() {
 		for event in Self::queued_events() {
+			match event {
+				Event::<T>::ContractSelfdestructed(contract, caller) => {
+					Self::remove_contract(&caller, &contract);
+				},
+				_ => {}
+			}
 			Pallet::<T>::deposit_event(event);
-
-			// match event {
-			// 	Event::<T>::ContractSelfdestructed(*EvmAddress) => {
-			//
-			// 	},
-			// 	_ => {}
-			// }
 		}
 		QueuedEvents::<T>::kill();
 	}

--- a/modules/evm/src/runner/handler.rs
+++ b/modules/evm/src/runner/handler.rs
@@ -415,18 +415,9 @@ impl<'vicinity, 'config, 'meter, T: Config> HandlerT for Handler<'vicinity, 'con
 			return Err(ExitError::OutOfGas);
 		}
 
-		let source = T::AddressMapping::get_account_id(&address);
-		let dest = T::AddressMapping::get_account_id(&target);
-
-		let size = Pallet::<T>::remove_account(&address)?;
-
-		self.storage_meter
-			.refund(size.saturating_add(T::NewContractExtraBytes::get()))
-			.map_err(|_| ExitError::Other("RefundStorageError".into()))?;
-
 		QueuedEvents::mutate(|v| v.push(Event::<T>::ContractSelfdestructed(address, target)));
 
-		T::TransferAll::transfer_all(&source, &dest).map_err(|_| ExitError::Other("TransferAllError".into()))
+		Ok(())
 	}
 
 	fn create(

--- a/modules/evm/src/runner/handler.rs
+++ b/modules/evm/src/runner/handler.rs
@@ -4,7 +4,7 @@ use crate::{
 	precompiles::Precompiles,
 	runner::storage_meter::{StorageMeter, StorageMeterHandler},
 	EvmAccountInfo, AccountStorages, Accounts, AddressMapping, Codes, Config, ContractInfo, Error, Event, Log,
-	TransferAll, Pallet, Vicinity, QueuedEvents
+	Pallet, Vicinity, QueuedEvents
 };
 use evm::{Capture, Context, CreateScheme, ExitError, ExitReason, Opcode, Runtime, Stack, Transfer};
 use evm_gasometer::{self as gasometer, Gasometer};

--- a/modules/evm/src/runner/handler.rs
+++ b/modules/evm/src/runner/handler.rs
@@ -424,7 +424,7 @@ impl<'vicinity, 'config, 'meter, T: Config> HandlerT for Handler<'vicinity, 'con
 			.refund(size.saturating_add(T::NewContractExtraBytes::get()))
 			.map_err(|_| ExitError::Other("RefundStorageError".into()))?;
 
-		QueuedEvents::mutate(|v| v.push(Event::<T>::ContractSelfdestructed(address)));
+		QueuedEvents::mutate(|v| v.push(Event::<T>::ContractSelfdestructed(address, target)));
 
 		T::TransferAll::transfer_all(&source, &dest).map_err(|_| ExitError::Other("TransferAllError".into()))
 	}

--- a/modules/evm/src/tests.rs
+++ b/modules/evm/src/tests.rs
@@ -1066,6 +1066,58 @@ fn should_selfdestruct() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(EVM::selfdestruct(Origin::signed(alice_account_id), contract_address));
+		let event = Event::EVM(crate::Event::ContractSelfdestructed(contract_address));
+		assert!(System::events().iter().any(|record| record.event == event));
+	});
+}
+
+#[cfg(feature = "with-ethereum-compatibility")]
+#[test]
+fn should_selfdestruct_via_evm_call() {
+	// pragma solidity ^0.8.4;
+	//
+	// contract Test {
+	// 	address payable private owner;
+	//
+	// 	constructor() {
+	// 		owner = payable(msg.sender);
+	// 	}
+	//
+	// 	function close () public {
+	// 		selfdestruct(owner);
+	// 	}
+	// }
+	let contract = from_hex("0x6080604052348015600f57600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555060a48061005e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c806343d726d614602d575b600080fd5b60336035565b005b60008054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16fffea26469706673582212207dacfac5a65fdfa63f19717f68c02f0b95d1548af0cdb1fb3ffe5c7384ecc29b64736f6c63430008070033").unwrap();
+
+	new_test_ext().execute_with(|| {
+		let alice_account_id = <Test as Config>::AddressMapping::get_account_id(&alice());
+
+		// create contract
+		let result = Runner::<Test>::create(
+			alice(),
+			contract.clone(),
+			0,
+			21_000_000,
+			21_000_000,
+			<Test as Config>::config(),
+		)
+		.unwrap();
+		let contract_address = result.address;
+		assert_eq!(result.used_storage, 328);
+		let alice_balance = INITIAL_BALANCE - 328 * <Test as Config>::StorageDepositPerByte::get();
+
+		assert_eq!(balance(alice()), alice_balance);
+
+		assert_ok!(EVM::call(
+			Origin::signed(<Test as Config>::AddressMapping::get_account_id(&alice())),
+			contract_address,
+			from_hex("0x43d726d6").unwrap(), // Test.close()
+			0,
+			1000000,
+			1000000,
+		));
+		let event = Event::EVM(crate::Event::ContractSelfdestructed(contract_address));
+		assert!(System::events().iter().any(|record| record.event == event));
 	});
 }
 

--- a/modules/evm/src/tests.rs
+++ b/modules/evm/src/tests.rs
@@ -1066,7 +1066,7 @@ fn should_selfdestruct() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(EVM::selfdestruct(Origin::signed(alice_account_id), contract_address));
-		let event = Event::EVM(crate::Event::ContractSelfdestructed(contract_address));
+		let event = Event::EVM(crate::Event::ContractSelfdestructed(contract_address, alice()));
 		assert!(System::events().iter().any(|record| record.event == event));
 	});
 }
@@ -1116,7 +1116,7 @@ fn should_selfdestruct_via_evm_call() {
 			1000000,
 			1000000,
 		));
-		let event = Event::EVM(crate::Event::ContractSelfdestructed(contract_address));
+		let event = Event::EVM(crate::Event::ContractSelfdestructed(contract_address, alice()));
 		assert!(System::events().iter().any(|record| record.event == event));
 	});
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -49,9 +49,9 @@ pub mod currency {
 	pub const REEF: Balance = DOLLARS;
 	pub const MILLI_REEF: Balance = REEF / 1_000;
 	pub const MICRO_REEF: Balance = REEF / 1_000_000;
-	
+
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 20 * REEF + (bytes as Balance) * 100 * MILLI_REEF
+		items as Balance * 20 * REEF + (bytes as Balance) * 10 * MILLI_REEF
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -591,7 +591,7 @@ parameter_types! {
 	//Out[3]: 13939
 	pub const ChainId: u64 = 13939;
 	// 10 REEF minimum storage deposit
-	pub const NewContractExtraBytes: u32 = 10_000;
+	pub const NewContractExtraBytes: u32 = 1_000;
 	pub const StorageDepositPerByte: Balance = 10 * MILLI_REEF;
 	pub const MaxCodeSize: u32 = 60 * 1024;
 	pub NetworkContractSource: H160 = H160::from_low_u64_be(0);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -592,7 +592,7 @@ parameter_types! {
 	pub const ChainId: u64 = 13939;
 	// 10 REEF minimum storage deposit
 	pub const NewContractExtraBytes: u32 = 10_000;
-	pub const StorageDepositPerByte: Balance = 1 * MILLI_REEF;
+	pub const StorageDepositPerByte: Balance = 10 * MILLI_REEF;
 	pub const MaxCodeSize: u32 = 60 * 1024;
 	pub NetworkContractSource: H160 = H160::from_low_u64_be(0);
 	pub const DeveloperDeposit: Balance = 1_000 * REEF;

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -464,7 +464,7 @@ fn test_evm_module() {
 			assert_eq!(last_event(), event);
 
 			// test EvmAccounts Lookup
-			assert_eq!(Balances::free_balance(alice_account_id()), 999999999999989633000000000000000);
+			assert_eq!(Balances::free_balance(alice_account_id()), 999999999999896330000000000000000);
 			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF));
 			let to = EvmAccounts::eth_address(&alice());
 			assert_ok!(Currencies::transfer(
@@ -473,7 +473,7 @@ fn test_evm_module() {
 				CurrencyId::Token(TokenSymbol::REEF),
 				amount(10 * MICRO_REEF)
 			));
-			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999989633000000000000000);
+			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999896330000000000000000);
 			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF) - amount(10 * MICRO_REEF));
 		});
 }

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -464,7 +464,7 @@ fn test_evm_module() {
 			assert_eq!(last_event(), event);
 
 			// test EvmAccounts Lookup
-			assert_eq!(Balances::free_balance(alice_account_id()), 999999999999896330000000000000000);
+			assert_eq!(Balances::free_balance(alice_account_id()), 999999999999986330000000000000000);
 			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF));
 			let to = EvmAccounts::eth_address(&alice());
 			assert_ok!(Currencies::transfer(
@@ -473,7 +473,7 @@ fn test_evm_module() {
 				CurrencyId::Token(TokenSymbol::REEF),
 				amount(10 * MICRO_REEF)
 			));
-			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999896330000000000000000);
+			assert_eq!(Balances::free_balance(alice_account_id()), 1009999999999986330000000000000000);
 			assert_eq!(Balances::free_balance(bob_account_id()), amount(1 * MILLI_REEF) - amount(10 * MICRO_REEF));
 		});
 }


### PR DESCRIPTION
This PR standardises the cost of storage (per byte) across the different pallets that charge for storage usage in the reef runtime.  This includes transactions, evm and multisig.  The cost per byte has been standardised at 10 mREEF.

closes: #62 